### PR TITLE
fix: footer links — Verana.io label, veranafoundation.org URL

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -185,12 +185,12 @@ const config: Config = {
           title: 'About Verana',
           items: [
             {
-              label: 'Verana Verifiable Trust Network',
+              label: 'Verana.io',
               href: 'https://verana.io',
             },
             {
               label: 'Foundation Website',
-              href: 'https://verana.foundation',
+              href: 'https://veranafoundation.org',
             }
             
           ],


### PR DESCRIPTION
Two footer corrections in `docusaurus.config.ts` (About Verana column):

- Label **"Verana Verifiable Trust Network"** → **"Verana.io"** (link unchanged, `https://verana.io`)
- **Foundation Website** now points to **`https://veranafoundation.org`** — was the old `verana.foundation` domain

Typecheck passes. Independent of #136 (design) and #137 (Docusaurus 3.10.1); same file as #137 but non-overlapping hunks.