### PR TITLE
fix(ci): pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
     
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '18'  # Use the Node.js version compatible with your Docusaurus build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,14 +23,14 @@ jobs:
     
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '18'  # Use the Node.js version compatible with your Docusaurus build
 
@@ -41,7 +41,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./build
       - name: Deploy to GitHub Pages
@@ -50,5 +50,5 @@ jobs:
           success()
           && github.ref == 'refs/heads/main'
           && github.repository == 'verana-labs/verana-docs'
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
   


### PR DESCRIPTION
## What

The org policy rejects `@vN` tag references ("all actions must be pinned to a full-length commit SHA"), so **no workflow in this repo can currently run** — e.g. the Build workflow refused to start on `fix/*` pushes. This pins every action in `build.yml` and `deploy.yml` to the full commit SHA of the **latest release within the major already in use** (no behavior change), with the version noted in a trailing comment:

| Action | Pinned release | SHA |
| --- | --- | --- |
| `actions/checkout` | v4.3.1 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/setup-node` | v4.4.0 | `49933ea5288caeca8642d1e84afbd3f7d6820020` |
| `actions/configure-pages` | v5.0.0 | `983d7736d9b0ae728b81ab479565c72886d7745b` |
| `actions/upload-pages-artifact` | v3.0.1 | `56afc609e74202658d3ffba0e8f6dda462b719fa` |
| `actions/deploy-pages` | v4.0.5 | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` |

SHAs resolved directly from the `actions/*` repos' release tags (`git ls-remote`).

## Validation

The branch is named `fix/*` on purpose: pushing it triggers the Build workflow using this branch's own (pinned) workflow file — if the run starts and builds, the policy is satisfied.

## Notes

- The `deploy.yml` (Pages deploy on push to `main`) uses the same pins, so the next merge to `main` deploys under the policy too.
- Merging this does **not** retroactively fix the refused runs on the other open PR branches (#136, #137, #138): the Build workflow triggers on branch pushes, so each needs a new push (e.g. rebase on main) or a `workflow_dispatch` run to go green.
- Heads-up, out of scope here: `build.yml` only triggers on `feat/*` and `fix/*` branch pushes — branches named otherwise (e.g. `design/*`, `chore/*`) get no CI at all. Worth switching to a `pull_request` trigger at some point.