### PR TITLE
fix(ci): bump upload-pages-artifact to v4.0.0 for nested SHA pin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: ./build
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## What

The Pages deploy on `main` still fails the org action policy with:

> The action `actions/upload-artifact@v4` is not allowed in verana-labs/verana-docs because all actions must be pinned to a full-length commit SHA.

No workflow references `upload-artifact` directly — `actions/upload-pages-artifact` is a **composite action**, and the v3.0.1 we pinned in #139 internally runs `uses: actions/upload-artifact@v4` **by tag**. The org policy evaluates nested references too.

## Fix

One line: bump `upload-pages-artifact` v3.0.1 → **v4.0.0** (`7b1f4a764d45c48632c6b24a0339c27f5614fb0b`), whose internal step is SHA-pinned to `actions/upload-artifact@ea165f8d…` (v4.6.2) — verified in its `action.yml`.

Also verified the other four pinned actions (`checkout`, `setup-node`, `configure-pages`, `deploy-pages`) are plain `node20` JS actions with no nested `uses:` — this was the only composite.

The deploy workflow only runs on push to `main`, so the proof comes with the merge.