### PR TITLE
ci: also build docs, chore, ci, and refactor branch pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,9 @@
 name: Build Docusaurus
 
 on:
-  push:
-    branches:
-      - feat/*
-      - fix/*
-      - docs/*
-      - chore/*
-      - ci/*
-      - refactor/*
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled]
 
   workflow_dispatch:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# .github/workflows/deploy.yml
+# .github/workflows/build.yml
 
 name: Build Docusaurus
 
@@ -7,6 +7,10 @@ on:
     branches:
       - feat/*
       - fix/*
+      - docs/*
+      - chore/*
+      - ci/*
+      - refactor/*
 
   workflow_dispatch:
 


### PR DESCRIPTION
The build workflow only ran on `feat/*` and `fix/*` pushes, so `docs/*` branches (and chore/ci/refactor) got no build check at all, on a docs repo. This adds them, so the site build runs before those changes reach `main`. Also fixes the stray `deploy.yml` header comment at the top of `build.yml`.
