### PR TITLE
docs: set trust_deposit_rate default to 5% (0.05)

### DIFF
--- a/docs/learn/verifiable-public-registry/60-onboarding-participants.md
+++ b/docs/learn/verifiable-public-registry/60-onboarding-participants.md
@@ -222,7 +222,7 @@ When the schema prices fees in trust units, these TU amounts are converted to na
 Trust deposit is explained in [Trust Deposit and Reputation](./trust-deposit-and-reputation).
 :::
 
-Example, using 20% for `trust_deposit_rate`:
+Example, using 5% for `trust_deposit_rate`:
 
 ```plantuml
 
@@ -233,10 +233,10 @@ scale max 1200 width
 
 package "Applicant" as issuer #7677ed {
     object "A Account" as issuera {
-         \t-1200 TUs
+         \t-1050 TUs
     }
     object "A Trust Deposit" as issuertd {
-         \t+200 TUs
+         \t+50 TUs
     }
 
 }
@@ -244,7 +244,7 @@ package "Applicant" as issuer #7677ed {
 object "Escrow Account" as escrow
 
 issuera -r-> escrow: \t+1000 TUs
-issuera --> issuertd:  \t+200 TUs
+issuera --> issuertd:  \t+50 TUs
 
 
 @enduml
@@ -263,10 +263,10 @@ scale max 1200 width
 
 package "Issuer Grantor B" as ig {
     object "IG Account" as iga {
-        \t+800 TUs
+        \t+950 TUs
     }
     object "IG Trust Deposit" as igtd {
-        \t+200 TUs
+        \t+50 TUs
     }
 }
 object "Escrow Account" as escrow
@@ -274,8 +274,8 @@ object "Escrow Account" as escrow
 
 
 escrow -r-> ig: \t+1000 TUs \t\t\t\t\t
-ig --> iga: \t+800 TUs
-ig --> igtd: \t+200 TUs
+ig --> iga: \t+950 TUs
+ig --> igtd: \t+50 TUs
 
 @enduml
 

--- a/docs/learn/verifiable-public-registry/70-credential-monetization.md
+++ b/docs/learn/verifiable-public-registry/70-credential-monetization.md
@@ -66,8 +66,8 @@ Fees denominated in trust units (TUs) are converted to native denom at execution
 
 Example with the Participant tree above:
 
-- Total paid by issuer #C for issuing a credential: (10 + 5) * (1 + `user_agent_reward_rate` + `wallet_user_agent_reward_rate` + `trust_deposit_rate`) = 21 TUs
-- Total paid by `Verifier E` for verifying a credential: (20 + 5 + 2 + 30) * (1 + `user_agent_reward_rate` + `wallet_user_agent_reward_rate` + `trust_deposit_rate`) = 79.8 TUs
+- Total paid by issuer #C for issuing a credential: (10 + 5) * (1 + `user_agent_reward_rate` + `wallet_user_agent_reward_rate` + `trust_deposit_rate`) = 18.75 TUs
+- Total paid by `Verifier E` for verifying a credential: (20 + 5 + 2 + 30) * (1 + `user_agent_reward_rate` + `wallet_user_agent_reward_rate` + `trust_deposit_rate`) = 71.25 TUs
 
 ## Fee Distribution Model
 
@@ -83,7 +83,7 @@ If not, they **must reject** the issuance or verification request.
 The **user agent** and **wallet user agent** may refer to the same implementation.
 :::
 
-Distribution example for the issuance by `ISSUER` #C of a credential, using the `Participant` tree above, 20% for `trust_deposit_rate`, 10% for `wallet_user_agent_reward_rate` and `user_agent_reward_rate`.
+Distribution example for the issuance by `ISSUER` #C of a credential, using the `Participant` tree above, 5% for `trust_deposit_rate`, 10% for `wallet_user_agent_reward_rate` and `user_agent_reward_rate`.
 
 ```plantuml
 
@@ -93,46 +93,46 @@ scale max 800 width
 
 package "Ecosystem #A" as tr #3fbdb6 {
     object "E Account" as tra {
-         \t+8 TUs
+         \t+9.5 TUs
     }
     object "E Trust Deposit" as trtd {
-         \t+2 TUs
+         \t+0.5 TUs
     }
 }
 
 package "Issuer Grantor #B" as ig {
     object "IG Account" as iga {
-        \t+4 TUs
+        \t+4.75 TUs
     }
     object "IG Trust Deposit" as igtd {
-        \t+1 TUs
+        \t+0.25 TUs
     }
 }
 package "Issuer #C" as issuer #b99bce {
     object "I Account" as issuera {
-         \t-21 TUs
+         \t-18.75 TUs
     }
     object "I Trust Deposit" as issuertd {
-         \t+3 TUs
+         \t+0.75 TUs
     }
 
 }
 
 package "User Agent" as ua {
     object "UA Account" as uaa {
-         \t+1.2 TUs
+         \t+1.425 TUs
     }
     object "UA Trust Deposit" as uatd {
-        \t+0.3 TUs
+        \t+0.075 TUs
     }
 
 }
 package "Wallet User Agent" as wua {
     object "WUA Account" as wuaa {
-         \t+1.2 TUs
+         \t+1.425 TUs
     }
     object "WUA Trust Deposit" as wuatd {
-        \t+0.3 TUs
+        \t+0.075 TUs
     }
 
 }
@@ -145,13 +145,13 @@ issuera -d-> ua: \t+1.5 TUs
 
 issuera -d-> wua: \t+1.5 TUs
 
-issuera --> issuertd:  \t+3 TUs
+issuera --> issuertd:  \t+0.75 TUs
 
 @enduml
 
 ```
 
-Distribution example for the verification by `VERIFIER` #E of a credential issued by `ISSUER` #C, using the `Participant` tree above, 20% for `trust_deposit_rate`, 10% for `wallet_user_agent_reward_rate` and `user_agent_reward_rate`.
+Distribution example for the verification by `VERIFIER` #E of a credential issued by `ISSUER` #C, using the `Participant` tree above, 5% for `trust_deposit_rate`, 10% for `wallet_user_agent_reward_rate` and `user_agent_reward_rate`.
 
 ```plantuml
 
@@ -160,63 +160,63 @@ Distribution example for the verification by `VERIFIER` #E of a credential issue
 
 package "Ecosystem #A" as tr #3fbdb6 {
     object "E Account" as tra {
-         \t+16 TUs
+         \t+19 TUs
     }
     object "E Trust Deposit" as trtd {
-         \t+4 TUs
+         \t+1 TUs
     }
 }
 
 package "Issuer Grantor #B" as ig {
     object "IG Account" as iga {
-        \t+4 TUs
+        \t+4.75 TUs
     }
     object "IG Trust Deposit" as igtd {
-        \t+1 TUs
+        \t+0.25 TUs
     }
 }
 package "Issuer #C" as issuer #b99bce {
     object "I Account" as issuera {
-         \t+24 TUs
+         \t+28.5 TUs
     }
     object "I Trust Deposit" as issuertd {
-         \t+6 TUs
+         \t+1.5 TUs
     }
 
 }
 package "Verifier Grantor #D" as vg {
     object "VG Account" as vga {
-        \t+1.6 TUs
+        \t+1.9 TUs
     }
     object "VG Trust Deposit" as vgtd {
-        \t+0.4 TUs
+        \t+0.1 TUs
     }
 
 }
 package "Verifier #E" as verifier #D88AB3 {
     object "V Account" as verifiera {
-        \t-79.8 TUs
+        \t-71.25 TUs
     }
     object "V Trust Deposit" as verifiertd {
-        \t+11.4 TUs
+        \t+2.85 TUs
     }
 
 }
 package "User Agent" as ua {
     object "UA Account" as uaa {
-         \t+4.56 TUs
+         \t+5.415 TUs
     }
     object "UA Trust Deposit" as uatd {
-        \t+1.14 TUs
+        \t+0.285 TUs
     }
 
 }
 package "Wallet User Agent" as wua {
     object "WUA Account" as wuaa {
-         \t+4.56 TUs
+         \t+5.415 TUs
     }
     object "WUA Trust Deposit" as wuatd {
-        \t+1.14 TUs
+        \t+0.285 TUs
     }
 
 }
@@ -234,7 +234,7 @@ verifiera -d-> ua: \t+5.7 TUs
 
 verifiera -d-> wua: \t+5.7 TUs
 
-verifiera --> verifiertd:  \t+11.4 TUs
+verifiera --> verifiertd:  \t+2.85 TUs
 
 @enduml
 

--- a/docs/learn/verifiable-public-registry/80-trust-deposit-and-reputation.md
+++ b/docs/learn/verifiable-public-registry/80-trust-deposit-and-reputation.md
@@ -110,11 +110,11 @@ verifiera --> verifiertd:  \t+11.4 TUs
 
 ```
 
-- Each time fees are charged, an additional **20%** (`trust_deposit_rate`) is added and allocated to the **trust deposit** of the Corporation executing the transaction. This amount is also linked to the specific `Participant` entry that authorized the transaction (tracked in the entry's `deposit` field).
+- Each time fees are charged, an additional **5%** (`trust_deposit_rate`) is added and allocated to the **trust deposit** of the Corporation executing the transaction. This amount is also linked to the specific `Participant` entry that authorized the transaction (tracked in the entry's `deposit` field).
 
-- When fees are distributed to other participants (e.g., issuers, grantors, etc.), **20%** of the distributed amount is redirected to their **trust deposit**, while the remaining **80%** is **liquid and immediately available** for use.
+- When fees are distributed to other participants (e.g., issuers, grantors, etc.), **5%** of the distributed amount is redirected to their **trust deposit**, while the remaining **95%** is **liquid and immediately available** for use.
 
-- The percentage allocated to trust deposits (`trust_deposit_rate`, default 20%) is a global variable configurable by the **VPR governance authority**.
+- The percentage allocated to trust deposits (`trust_deposit_rate`, default 5%) is a global variable configurable by the **VPR governance authority**.
 
 ### Trust Deposit Yield
 

--- a/docs/run/network/modules/15-trust-deposit.md
+++ b/docs/run/network/modules/15-trust-deposit.md
@@ -145,7 +145,7 @@ veranad q td params --node $NODE_RPC --output json
   "params": {
     "trust_deposit_reclaim_burn_rate": "0",
     "trust_deposit_share_value": "1000000025000000000",
-    "trust_deposit_rate": "200000000000000000",
+    "trust_deposit_rate": "50000000000000000",
     "wallet_user_agent_reward_rate": "100000000000000000",
     "user_agent_reward_rate": "100000000000000000",
     "trust_deposit_max_yield_rate": "200000000000000000",

--- a/docs/use/trust-deposit-and-reputation/00-trust-deposit-operations.md
+++ b/docs/use/trust-deposit-and-reputation/00-trust-deposit-operations.md
@@ -269,7 +269,7 @@ veranad q td params --node $NODE_RPC --output json
   "params": {
     "trust_deposit_reclaim_burn_rate": "0",
     "trust_deposit_share_value": "1000000025000000000",
-    "trust_deposit_rate": "200000000000000000",
+    "trust_deposit_rate": "50000000000000000",
     "wallet_user_agent_reward_rate": "100000000000000000",
     "user_agent_reward_rate": "100000000000000000",
     "trust_deposit_max_yield_rate": "200000000000000000",

--- a/docs/use/trust-deposit-and-reputation/15-update-params.md
+++ b/docs/use/trust-deposit-and-reputation/15-update-params.md
@@ -53,7 +53,7 @@ cat > trust_deposit_params_proposal.json <<JSON
       "params": {
         "trust_deposit_reclaim_burn_rate": "0",
         "trust_deposit_share_value": "${SHARE_VALUE}",
-        "trust_deposit_rate": "200000000000000000",
+        "trust_deposit_rate": "50000000000000000",
         "wallet_user_agent_reward_rate": "100000000000000000",
         "user_agent_reward_rate": "100000000000000000",
         "trust_deposit_max_yield_rate": "200000000000000000",

--- a/docs/use/trust-deposit-and-reputation/20-reputation-computation.md
+++ b/docs/use/trust-deposit-and-reputation/20-reputation-computation.md
@@ -8,7 +8,7 @@ This page describes the on-chain signals the model is built from and how to read
 
 Reputation is anchored in the trust deposit economics:
 
-- A trust deposit is keyed by **`corporation_id`** and **grows automatically** as the Corporation performs trust operations (onboarding processes, credential issuance and verification, participant registration). Each trust fee adds `trust_deposit_rate` (default 20%) to the executing Corporation's deposit.
+- A trust deposit is keyed by **`corporation_id`** and **grows automatically** as the Corporation performs trust operations (onboarding processes, credential issuance and verification, participant registration). Each trust fee adds `trust_deposit_rate` (default 5%) to the executing Corporation's deposit.
 - A trust deposit is **non-withdrawable** and earns **yield**: `trust_deposit_share_value` starts at 1 and increases every block as block-reward yield is distributed (capped by `trust_deposit_max_yield_rate`). A larger, longer-held deposit therefore signals sustained, rule-abiding participation.
 - **Slashing** subtracts from the deposit and is permanently recorded (`slashed_deposit`, `slash_count`, `last_slashed`), acting as a negative signal until repaid.
 

--- a/docs/use/verifiable-user-agent-builders/70-ecosystem-rewards.md
+++ b/docs/use/verifiable-user-agent-builders/70-ecosystem-rewards.md
@@ -30,7 +30,7 @@ veranad query td params
   "params": {
     "trust_deposit_reclaim_burn_rate": "0",
     "trust_deposit_share_value": "1000000025000000000",
-    "trust_deposit_rate": "200000000000000000",
+    "trust_deposit_rate": "50000000000000000",
     "wallet_user_agent_reward_rate": "100000000000000000",
     "user_agent_reward_rate": "100000000000000000",
     "trust_deposit_max_yield_rate": "200000000000000000",


### PR DESCRIPTION
## What

Sets the default value of `trust_deposit_rate` to **5% (0.05)**, previously 20% (0.20), matching the tokenomics decision and the VPR spec change (verana-labs/verifiable-trust-vpr-spec#153).

## Changes

- Prose defaults: `learn/.../80-trust-deposit-and-reputation.md` (20% → 5%, 80% → 95% liquid split), `use/.../20-reputation-computation.md` (default 20% → 5%).
- Worked examples recomputed at 5% (agent reward rates unchanged): onboarding example in `learn/.../60-onboarding-participants.md`, pay-per issuance/verification examples in `learn/.../70-credential-monetization.md` (totals 21 → 18.75, 79.8 → 71.25).
- JSON parameter examples: `"trust_deposit_rate"` `200000000000000000` → `50000000000000000` (0.05) in the trust-deposit module page, update-params guide, trust-deposit-operations guide, and ecosystem-rewards guide.

Other parameters (`trust_deposit_block_reward_share`, agent reward rates, yield rates) are untouched. Versioned v3 docs are intentionally untouched.

## Note

Some of these JSON blocks are labeled "live testnet values" — devnet/testnet still run `0.20` until a `MsgUpdateParams` governance proposal updates the chain; this PR documents the new default.